### PR TITLE
Increase coverage of GenericPublisherTest

### DIFF
--- a/src/test/java/net/reini/rabbitmq/cdi/GenericPublisherTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/GenericPublisherTest.java
@@ -6,19 +6,16 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.AMQP.BasicProperties.Builder;
 import com.rabbitmq.client.Channel;
@@ -34,6 +31,8 @@ public class GenericPublisherTest {
   private Connection connection;
   @Mock
   private Channel channel;
+  @Mock
+  private Encoder<TestEvent> encoder;
   @Mock
   BiConsumer<?, PublishException> errorHandler;
 
@@ -91,6 +90,22 @@ public class GenericPublisherTest {
   }
 
   @Test
+  public void testPublish_withEncodeException() throws Exception {
+    Builder builder = new Builder();
+    PublisherConfiguration publisherConfiguration = new PublisherConfiguration(config, "exchange",
+        "routingKey", builder, encoder, errorHandler);
+
+    when(connectionProducer.getConnection(config)).thenReturn(connection);
+    when(connection.createChannel()).thenReturn(channel);
+    doThrow(new EncodeException(new RuntimeException("someError"))).when(encoder).encode(event);
+
+    Throwable exception = assertThrows(PublishException.class, () -> {
+      publisher.publish(event, publisherConfiguration);
+    });
+    assertEquals("Unable to serialize event", exception.getMessage());
+  }
+
+  @Test
   public void testPublish_with_custom_MessageConverter() throws Exception {
     Builder builder = new Builder();
     PublisherConfiguration publisherConfiguration = new PublisherConfiguration(config, "exchange",
@@ -129,6 +144,17 @@ public class GenericPublisherTest {
     publisher.closeChannel(channel);
   }
 
+  @Test
+  public void testHandleIoException_channel_null() throws PublishException {
+    publisher.handleIoException(null, 1, null);
+  }
+
+  @Test
+  public void testSleepBeforeRetry_InterruptedException() throws InterruptedException {
+    publisher = new GenericPublisher(connectionProducer);
+    call_SleepBeforeRetry_InAnotherThread_AndInterrupt();
+  }
+
   public static class CustomEncoder implements Encoder<TestEvent> {
     @Override
     public String contentType() {
@@ -142,5 +168,17 @@ public class GenericPublisherTest {
           MessageFormat.format("Id: {0}, BooleanValue: {1}", event.getId(), event.isBooleanValue());
       return str.getBytes();
     }
+  }
+
+  private void call_SleepBeforeRetry_InAnotherThread_AndInterrupt() throws InterruptedException {
+    Thread sleeper = new Thread("sleeper") {
+      @Override
+      public void run() {
+        publisher.sleepBeforeRetry();
+      }
+    };
+    sleeper.start();
+    Thread.sleep(GenericPublisher.DEFAULT_RETRY_INTERVAL / 4);
+    sleeper.interrupt();
   }
 }


### PR DESCRIPTION
The `for` loop still misses one branch. But I found it impossible - even with the worst reflection tricks from stackoverflow - to change the `static final DEFAULT_RETRY_ATTEMPTS` constant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reinhapa/rabbitmq-cdi/16)
<!-- Reviewable:end -->
