### PR TITLE
Fb basicqos

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,6 +124,7 @@ public class BindingInitializer {
         .setConnectTimeout(10000) // <5>
         .setConnectRetryWaitTime(10000) // <6>
         .setRequestedConnectionHeartbeatTimeout(3) // <7>
+        .withPrefetchCount(5); //8
       binder.initialize();
     } catch (IOException e) {
       LoggerFactory.getLogger(getClass()).error("Unable to initialize", e);
@@ -138,6 +139,7 @@ public class BindingInitializer {
 <5> Sets the connect timeout to 10 sec
 <6> Set the time to wait between connection retries to 10 sec
 <7> Set the heartbeat timeout to 3 sec (To detect connection problems)
+<8> Set the prefetch count which configures how many messages are downloaded at once from broker
 
 
 === Alternative connection definition

--- a/src/main/java/net/reini/rabbitmq/cdi/ConsumerContainer.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConsumerContainer.java
@@ -40,9 +40,9 @@ class ConsumerContainer {
     this.declarerRepository = declarerRepository;
   }
 
-  public void addConsumer(EventConsumer consumer, String queue, boolean autoAck, List<Declaration> declarations) {
+  public void addConsumer(EventConsumer consumer, String queue, boolean autoAck, int prefetchCount, List<Declaration> declarations) {
     ConsumerHolder consumerHolder = consumerHolderFactory.createConsumerHolder(consumer, queue,
-        autoAck, connectionRepository, config, declarations, declarerRepository);
+        autoAck, prefetchCount, connectionRepository, config, declarations, declarerRepository);
     consumerHolders.add(consumerHolder);
   }
 

--- a/src/main/java/net/reini/rabbitmq/cdi/ConsumerHolder.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConsumerHolder.java
@@ -22,15 +22,17 @@ class ConsumerHolder {
   private final ConsumerFactory consumerFactory;
   private final DeclarerRepository declarerRepository;
   private final List<Declaration> declarations;
+  private final int prefetchCount;
   private Channel channel;
 
   private volatile boolean active;
 
-  ConsumerHolder(EventConsumer consumer, String queueName, boolean autoAck,
+  ConsumerHolder(EventConsumer consumer, String queueName, boolean autoAck,int prefetchCount,
       ConsumerChannelFactory consumerChannelFactory, ConsumerFactory consumerFactory, List<Declaration> declarations, DeclarerRepository declarerRepository) {
     this.consumer = consumer;
     this.queueName = queueName;
     this.autoAck = autoAck;
+    this.prefetchCount = prefetchCount;
     this.consumerChannelFactory = consumerChannelFactory;
     this.declarations = declarations;
     this.declarerRepository = declarerRepository;
@@ -60,6 +62,7 @@ class ConsumerHolder {
           channel = this.consumerChannelFactory.createChannel();
           channel.addShutdownListener(shutdownListener);
           declarerRepository.declare(channel, declarations);
+          channel.basicQos(this.prefetchCount);
           channel.basicConsume(queueName, autoAck, autoAck ? consumerFactory.create(consumer)
               : consumerFactory.createAcknowledged(consumer, channel));
           LOGGER.info("Activated consumer of class {}", consumer.getClass());

--- a/src/main/java/net/reini/rabbitmq/cdi/ConsumerHolderFactory.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConsumerHolderFactory.java
@@ -3,12 +3,12 @@ package net.reini.rabbitmq.cdi;
 import java.util.List;
 
 class ConsumerHolderFactory {
-  ConsumerHolder createConsumerHolder(EventConsumer consumer, String queue, boolean autoAck,
+  ConsumerHolder createConsumerHolder(EventConsumer consumer, String queue, boolean autoAck, int prefetchCount,
       ConnectionRepository connectionRepository, ConnectionConfig config, List<Declaration> declarations,DeclarerRepository declarerRepository) {
     ConsumerChannelFactory consumerChannelFactory =
         new ConsumerChannelFactory(connectionRepository, config);
     ConsumerFactory consumerFactory = new ConsumerFactory();
-    return new ConsumerHolder(consumer, queue, autoAck, consumerChannelFactory, consumerFactory,
+    return new ConsumerHolder(consumer, queue, autoAck, prefetchCount, consumerChannelFactory, consumerFactory,
         declarations, declarerRepository);
   }
 }

--- a/src/test/java/net/reini/rabbitmq/cdi/ConsumerContainerTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/ConsumerContainerTest.java
@@ -54,8 +54,8 @@ class ConsumerContainerTest {
         new ConsumerContainer(connectionConfigMock, connectionRepositoryMock,declarerRepositoryMock, consumerHolders,
              consumerHolderFactoryMock, lockMock);
     when(consumerHolderFactoryMock.createConsumerHolder(consumerMock, EXPECTED_QUEUE_NAME,
-        EXPECTED_AUTOACK, connectionRepositoryMock, connectionConfigMock, declarations,declarerRepositoryMock)).thenReturn(consumerHolderMock);
-    sut.addConsumer(consumerMock, EXPECTED_QUEUE_NAME, EXPECTED_AUTOACK, declarations);
+        EXPECTED_AUTOACK, 0, connectionRepositoryMock, connectionConfigMock, declarations,declarerRepositoryMock)).thenReturn(consumerHolderMock);
+    sut.addConsumer(consumerMock, EXPECTED_QUEUE_NAME, EXPECTED_AUTOACK, 0, declarations);
 
     assertEquals(1, consumerHolders.size());
     ConsumerHolder consumerHolder = consumerHolders.get(0);

--- a/src/test/java/net/reini/rabbitmq/cdi/ConsumerHolderFactoryTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/ConsumerHolderFactoryTest.java
@@ -27,7 +27,7 @@ class ConsumerHolderFactoryTest {
   void testCreate() {
     ConsumerHolderFactory consumerHolderFactory = new ConsumerHolderFactory();
     ConsumerHolder consumerHolder =
-        consumerHolderFactory.createConsumerHolder(eventConsumerMock, "queue", true,
+        consumerHolderFactory.createConsumerHolder(eventConsumerMock, "queue", true, 0,
             connectionRepositoryMock, configMock, declarations,declarerRepositoryMock);
     assertNotNull(consumerHolder);
   }

--- a/src/test/java/net/reini/rabbitmq/cdi/QueueBindingTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/QueueBindingTest.java
@@ -49,6 +49,13 @@ class QueueBindingTest {
   }
 
   @Test
+  void testWithPrefetchCount() {
+    assertEquals(0, binding.getPrefetchCount());
+    assertSame(binding, binding.withPrefetchCount(5));
+    assertEquals(5,binding.getPrefetchCount());
+  }
+
+  @Test
   void testGetDecoder() {
     assertEquals(JsonDecoder.class, binding.getDecoder().getClass());
     assertSame(binding, binding.withDecoder(decoder));


### PR DESCRIPTION
Made prefetch count configurable.
As we need to scale with multiple consumer servers, it is important to have the prefetch count configurable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reinhapa/rabbitmq-cdi/26)
<!-- Reviewable:end -->
