### PR TITLE
Bugfix wrong port/host in retry log message

### DIFF
--- a/src/main/java/net/reini/rabbitmq/cdi/ConnectionManager.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConnectionManager.java
@@ -110,8 +110,7 @@ class ConnectionManager {
   }
 
   boolean tryToEstablishConnection() {
-    String connectWarning = "could not establish connection to host " + connectionFactory.getHost()
-        + " on port " + connectionFactory.getPort() + ", retry to establish connection...";
+
     if (state == ConnectionState.CONNECTED || state == ConnectionState.CLOSED) {
       throw new IllegalStateException(
           "connection manager illegal state to establish a connection: " + state);
@@ -122,7 +121,7 @@ class ConnectionManager {
       connection = createNewConnection();
       return true;
     } catch (IOException | TimeoutException e) {
-      LOGGER.warn(connectWarning);
+      LOGGER.warn("could not establish connection to {} Retry to establish connection...", config);
       LOGGER.debug("could not establish connection", e);
     } finally {
       connectionManagerLock.unlock();


### PR DESCRIPTION
Corrected retry log message fixes #27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reinhapa/rabbitmq-cdi/31)
<!-- Reviewable:end -->
