### PR TITLE
Adding methods to register and remove ConnectionListener

### DIFF
--- a/src/main/java/net/reini/rabbitmq/cdi/ConnectionManager.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConnectionManager.java
@@ -96,6 +96,11 @@ class ConnectionManager {
     this.listeners.remove(listener);
   }
 
+  public boolean containsListener( ConnectionListener listener )
+  {
+    return this.listeners.contains( listener );
+  }
+
   /**
    * Changes the factory state and notifies all connection listeners.
    *

--- a/src/main/java/net/reini/rabbitmq/cdi/ConnectionRepository.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/ConnectionRepository.java
@@ -126,4 +126,18 @@ public class ConnectionRepository {
     connectionManagers.computeIfAbsent(config, connectionManagerFactoryFunction)
         .removeListener(listener);
   }
+
+
+  /**
+   * Checks if the given listener is already added to the factory
+   *
+   * @param configuration
+   * @param connectionListener
+   * @return true if the given connection listener is already added, otherwise false
+   */
+  public boolean containsConnectionListener(ConnectionConfig config, ConnectionListener listener)
+  {
+    return connectionManagers.computeIfAbsent(config, connectionManagerFactoryFunction)
+            .containsListener(listener);
+  }
 }

--- a/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
@@ -208,6 +208,8 @@ public abstract class EventBinder {
 
   /**
    *  Registers a {@link ConnectionListener} to the connection which is used by this object.
+   *
+   * @param connectionListener the {@link ConnectionListener} which should be registered
    */
   public void registerConnectionListener(ConnectionListener connectionListener)
   {
@@ -216,6 +218,8 @@ public abstract class EventBinder {
 
   /**
    *  Removes a {@link ConnectionListener} from the connection which is used by this object.
+   *
+   * @param connectionListener the {@link ConnectionListener} which should be removed
    */
   public void removeConnectionListener(ConnectionListener connectionListener){
     connectionRepository.removeConnectionListener( configuration, connectionListener );

--- a/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
@@ -208,12 +208,17 @@ public abstract class EventBinder {
 
   /**
    *  Registers a {@link ConnectionListener} to the connection which is used by this object.
+   *  <p>
+   *  Note: The {@link ConnectionListener} will be added only once, if this method called with the same
+   *  {@link ConnectionListener} multiple times.
+   *  </p>
    *
    * @param connectionListener the {@link ConnectionListener} which should be registered
    */
   public void registerConnectionListener(ConnectionListener connectionListener)
   {
-    connectionRepository.registerConnectionListener( configuration, connectionListener );
+    if( !connectionRepository.containsConnectionListener( configuration, connectionListener ))
+      connectionRepository.registerConnectionListener( configuration, connectionListener );
   }
 
   /**

--- a/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
+++ b/src/main/java/net/reini/rabbitmq/cdi/EventBinder.java
@@ -205,6 +205,22 @@ public abstract class EventBinder {
     consumerContainer.start();
   }
 
+
+  /**
+   *  Registers a {@link ConnectionListener} to the connection which is used by this object.
+   */
+  public void registerConnectionListener(ConnectionListener connectionListener)
+  {
+    connectionRepository.registerConnectionListener( configuration, connectionListener );
+  }
+
+  /**
+   *  Removes a {@link ConnectionListener} from the connection which is used by this object.
+   */
+  public void removeConnectionListener(ConnectionListener connectionListener){
+    connectionRepository.removeConnectionListener( configuration, connectionListener );
+  }
+
   @PostConstruct
   void initializeConsumerContainer() {
     configuration = new ConnectionConfiguration();

--- a/src/test/java/net/reini/rabbitmq/cdi/ConnectionManagerTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/ConnectionManagerTest.java
@@ -149,6 +149,11 @@ class ConnectionManagerTest {
   }
 
   @Test
+  public void testContainsListener() {
+    assertTrue(sut.containsListener(listener));
+  }
+
+  @Test
   public void testCreateConnection()
       throws TimeoutException, IOException {
     when(configMock.createConnection(connectionFactoryMock)).thenReturn(connectionMock);

--- a/src/test/java/net/reini/rabbitmq/cdi/ConnectionRepositoryTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/ConnectionRepositoryTest.java
@@ -24,7 +24,9 @@
 
 package net.reini.rabbitmq.cdi;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.function.Function;

--- a/src/test/java/net/reini/rabbitmq/cdi/ConnectionRepositoryTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/ConnectionRepositoryTest.java
@@ -24,8 +24,7 @@
 
 package net.reini.rabbitmq.cdi;
 
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.function.Function;
@@ -81,6 +80,12 @@ public class ConnectionRepositoryTest {
 
     sut.removeConnectionListener(configMock, listener);
     verify(connectionManagerMock).removeListener(listener);
+  }
+
+  @Test
+  public void testContainsConnectionListener() {
+    sut.containsConnectionListener(configMock, listener);
+    verify(connectionManagerMock, times( 1 )).containsListener( listener );
   }
 
   @Test

--- a/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
@@ -129,7 +129,7 @@ class EventBinderTest {
     ContainerConnectionListener sut =
             new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);
     eventBinder.registerConnectionListener( sut );
-    Mockito.verify(connectionRepository, Mockito.times(1)).registerConnectionListener( Mockito.any(), Mockito.eq(sut) );
+    verify(connectionRepository, Mockito.times(1)).registerConnectionListener( Mockito.any(), Mockito.eq(sut) );
   }
 
   @Test
@@ -137,7 +137,7 @@ class EventBinderTest {
     ContainerConnectionListener sut =
             new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);
     eventBinder.removeConnectionListener( sut );
-    Mockito.verify(connectionRepository, Mockito.times(1)).removeConnectionListener( Mockito.any(), Mockito.eq(sut) );
+    verify(connectionRepository, Mockito.times(1)).removeConnectionListener( Mockito.any(), Mockito.eq(sut) );
   }
 
   static class TestEventBinder extends EventBinder {

--- a/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
@@ -133,6 +133,17 @@ class EventBinderTest {
   }
 
   @Test
+  void testDuplicateAddListener() throws IOException {
+    ContainerConnectionListener sut =
+            new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);
+    eventBinder.registerConnectionListener( sut );
+    Mockito.when(connectionRepository.containsConnectionListener( Mockito.any(), Mockito.eq( sut ) ) ).thenReturn( true );
+    eventBinder.registerConnectionListener( sut );
+    verify(connectionRepository, Mockito.times(1 )).registerConnectionListener( Mockito.any(), Mockito.eq(sut) );
+    verify(connectionRepository, Mockito.times( 2 )).containsConnectionListener( Mockito.any(), Mockito.eq(sut) );
+  }
+
+  @Test
   void testRemoveListener() throws IOException {
     ContainerConnectionListener sut =
             new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);

--- a/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
+++ b/src/test/java/net/reini/rabbitmq/cdi/EventBinderTest.java
@@ -29,6 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Instance;
@@ -58,7 +60,10 @@ class EventBinderTest {
   private ConsumerContainerFactory consumerContainerFactory;
   @Mock
   private ConsumerContainer consumerContainerMock;
-
+  @Mock
+  private ReentrantLock lockMock;
+  @Mock
+  private Condition conditionMock;
 
   @InjectMocks
   private TestEventBinder eventBinder;
@@ -117,6 +122,22 @@ class EventBinderTest {
   @Test
   void testDeclarerFactoryNotNUll() {
     assertNotNull(eventBinder.declarerFactory());
+  }
+
+  @Test
+  void testAddListener() throws IOException {
+    ContainerConnectionListener sut =
+            new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);
+    eventBinder.registerConnectionListener( sut );
+    Mockito.verify(connectionRepository, Mockito.times(1)).registerConnectionListener( Mockito.any(), Mockito.eq(sut) );
+  }
+
+  @Test
+  void testRemoveListener() throws IOException {
+    ContainerConnectionListener sut =
+            new ContainerConnectionListener(consumerContainerMock, lockMock, conditionMock);
+    eventBinder.removeConnectionListener( sut );
+    Mockito.verify(connectionRepository, Mockito.times(1)).removeConnectionListener( Mockito.any(), Mockito.eq(sut) );
   }
 
   static class TestEventBinder extends EventBinder {


### PR DESCRIPTION
Hi,
we using our own Implementations of the ConnectionListener interface for internal health checks in Kubernetes and business logics.
This PR enables to register own ConnectionListener implementations to the EventBinder.

Kind regards
Stefan

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reinhapa/rabbitmq-cdi/120)
<!-- Reviewable:end -->
